### PR TITLE
Add an eviction rate limiter on the updater

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "0.5.0"
+const VerticalPodAutoscalerVersion = "0.5.1"

--- a/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/admission-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:v1.0.0
+FROM k8s.gcr.io/debian-base-amd64:1.0.0
 MAINTAINER Tomasz Kulczynski "tkulczynski@google.com"
 
 ADD admission-controller admission-controller

--- a/vertical-pod-autoscaler/pkg/recommender/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/recommender/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base-amd64:v1.0.0
+FROM k8s.gcr.io/debian-base-amd64:1.0.0
 MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
 
 ADD recommender recommender

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -212,10 +212,12 @@ func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider histor
 				ContainerName: containerName}
 			klog.V(4).Infof("Adding %d samples for container %v", len(sampleList), containerID)
 			for _, sample := range sampleList {
-				feeder.clusterState.AddSample(
+				if err := feeder.clusterState.AddSample(
 					&model.ContainerUsageSampleWithKey{
 						ContainerUsageSample: sample,
-						Container:            containerID})
+						Container:            containerID}); err != nil {
+					klog.Warningf("Error adding metric sample for container %v: %v", containerID, err)
+				}
 			}
 		}
 	}
@@ -372,13 +374,18 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics() {
 	}
 
 	sampleCount := 0
+	droppedSampleCount := 0
 	for _, containerMetrics := range containersMetrics {
 		for _, sample := range newContainerUsageSamplesWithKey(containerMetrics) {
-			feeder.clusterState.AddSample(sample)
-			sampleCount++
+			if err := feeder.clusterState.AddSample(sample); err != nil {
+				klog.Warningf("Error adding metric sample for container %v: %v", sample.Container, err)
+				droppedSampleCount++
+			} else {
+				sampleCount++
+			}
 		}
 	}
-	klog.V(3).Infof("ClusterSpec fed with #%v ContainerUsageSamples for #%v containers", sampleCount, len(containersMetrics))
+	klog.V(3).Infof("ClusterSpec fed with #%v ContainerUsageSamples for #%v containers. Dropped #%v samples.", sampleCount, len(containersMetrics), droppedSampleCount)
 
 Loop:
 	for {

--- a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerfetcher
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	cacheddiscovery "k8s.io/client-go/discovery/cached"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/scale"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+type wellKnownController string
+
+const (
+	daemonSet             wellKnownController = "DaemonSet"
+	deployment            wellKnownController = "Deployment"
+	replicaSet            wellKnownController = "ReplicaSet"
+	statefulSet           wellKnownController = "StatefulSet"
+	replicationController wellKnownController = "ReplicationController"
+	job                   wellKnownController = "Job"
+)
+
+var wellKnownControllers = []wellKnownController{daemonSet, deployment, replicaSet, statefulSet, replicationController, job}
+
+const (
+	discoveryResetPeriod time.Duration = 5 * time.Minute
+)
+
+// ControllerKey identifies a controller.
+type ControllerKey struct {
+	Namespace string
+	Kind      string
+	Name      string
+}
+
+// ControllerKeyWithAPIVersion identifies a controller and API it's defined in.
+type ControllerKeyWithAPIVersion struct {
+	ControllerKey
+	ApiVersion string
+}
+
+// ControllerFetcher is responsible for finding the top level controller
+type ControllerFetcher interface {
+	// FindTopLevel returns top level controller. Error is returned if top level controller cannot be found.
+	FindTopLevel(controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error)
+}
+
+type controllerFetcher struct {
+	scaleNamespacer scale.ScalesGetter
+	mapper          apimeta.RESTMapper
+	informersMap    map[wellKnownController]cache.SharedIndexInformer
+}
+
+// NewControllerFetcher returns a new instance of controllerFetcher
+func NewControllerFetcher(config *rest.Config, kubeClient kube_client.Interface, factory informers.SharedInformerFactory) ControllerFetcher {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		klog.Fatalf("Could not create discoveryClient: %v", err)
+	}
+	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
+	restClient := kubeClient.CoreV1().RESTClient()
+	cachedDiscoveryClient := cacheddiscovery.NewMemCacheClient(discoveryClient)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	go wait.Until(func() {
+		mapper.Reset()
+	}, discoveryResetPeriod, make(chan struct{}))
+
+	informersMap := map[wellKnownController]cache.SharedIndexInformer{
+		daemonSet:             factory.Apps().V1().DaemonSets().Informer(),
+		deployment:            factory.Apps().V1().Deployments().Informer(),
+		replicaSet:            factory.Apps().V1().ReplicaSets().Informer(),
+		statefulSet:           factory.Apps().V1().StatefulSets().Informer(),
+		replicationController: factory.Core().V1().ReplicationControllers().Informer(),
+		job:                   factory.Batch().V1().Jobs().Informer(),
+	}
+
+	for kind, informer := range informersMap {
+		stopCh := make(chan struct{})
+		go informer.Run(stopCh)
+		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
+		if !synced {
+			klog.Warningf("Could not sync cache for %s: %v", kind, err)
+		} else {
+			klog.Infof("Initial sync of %s completed", kind)
+		}
+	}
+
+	scaleNamespacer := scale.New(restClient, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
+	return &controllerFetcher{
+		scaleNamespacer: scaleNamespacer,
+		mapper:          mapper,
+		informersMap:    informersMap,
+	}
+}
+
+func getOwnerController(owners []metav1.OwnerReference, namespace string) *ControllerKeyWithAPIVersion {
+	for _, owner := range owners {
+		if owner.Controller != nil && *owner.Controller == true {
+			return &ControllerKeyWithAPIVersion{
+				ControllerKey: ControllerKey{
+					Namespace: namespace,
+					Kind:      owner.Kind,
+					Name:      owner.Name,
+				},
+				ApiVersion: owner.APIVersion,
+			}
+		}
+	}
+	return nil
+}
+
+func getParentOfWellKnownController(informer cache.SharedIndexInformer, controllerKey ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	namespace := controllerKey.Namespace
+	name := controllerKey.Name
+	kind := controllerKey.Kind
+
+	obj, exists, err := informer.GetStore().GetByKey(namespace + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("%s %s/%s does not exist", kind, namespace, name)
+	}
+	switch obj.(type) {
+	case (*appsv1.DaemonSet):
+		apiObj, ok := obj.(*appsv1.DaemonSet)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	case (*appsv1.Deployment):
+		apiObj, ok := obj.(*appsv1.Deployment)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	case (*appsv1.StatefulSet):
+		apiObj, ok := obj.(*appsv1.StatefulSet)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	case (*appsv1.ReplicaSet):
+		apiObj, ok := obj.(*appsv1.ReplicaSet)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	case (*batchv1.Job):
+		apiObj, ok := obj.(*batchv1.Job)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	case (*corev1.ReplicationController):
+		apiObj, ok := obj.(*corev1.ReplicationController)
+		if !ok {
+			return nil, fmt.Errorf("Failed to parse %s %s/%s", kind, namespace, name)
+		}
+		return getOwnerController(apiObj.OwnerReferences, namespace), nil
+	}
+
+	return nil, fmt.Errorf("Don't know how to read owner controller")
+}
+
+func (f *controllerFetcher) getParentOfController(controllerKey ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	kind := wellKnownController(controllerKey.Kind)
+	informer, exists := f.informersMap[kind]
+	if exists {
+		return getParentOfWellKnownController(informer, controllerKey)
+	}
+
+	// TODO: cache response
+	groupVersion, err := schema.ParseGroupVersion(controllerKey.ApiVersion)
+	if err != nil {
+		return nil, err
+	}
+	groupKind := schema.GroupKind{
+		Group: groupVersion.Group,
+		Kind:  controllerKey.Kind,
+	}
+
+	owner, err := f.getOwnerForScaleResource(groupKind, controllerKey.Namespace, controllerKey.Name)
+	if err != nil {
+		return nil, fmt.Errorf("Unhandled targetRef %s / %s / %s, last error %v",
+			controllerKey.ApiVersion, controllerKey.Kind, controllerKey.Name, err)
+	}
+
+	return owner, nil
+}
+
+func (f *controllerFetcher) getOwnerForScaleResource(groupKind schema.GroupKind, namespace, name string) (*ControllerKeyWithAPIVersion, error) {
+	mappings, err := f.mapper.RESTMappings(groupKind)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastError error
+	for _, mapping := range mappings {
+		groupResource := mapping.Resource.GroupResource()
+		scale, err := f.scaleNamespacer.Scales(namespace).Get(groupResource, name)
+		if err == nil {
+			return getOwnerController(scale.OwnerReferences, namespace), nil
+		}
+		lastError = err
+	}
+
+	// nothing found, apparently the resource doesn't support scale (or we lack RBAC)
+	return nil, lastError
+}
+
+func (f *controllerFetcher) FindTopLevel(key *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	if key == nil {
+		return nil, nil
+	}
+	visited := make(map[ControllerKeyWithAPIVersion]bool)
+	visited[*key] = true
+	for {
+		owner, err := f.getParentOfController(*key)
+		if err != nil {
+			return nil, err
+		}
+		if owner == nil {
+			return key, nil
+		}
+		_, alreadyVisited := visited[*owner]
+		if alreadyVisited {
+			return nil, fmt.Errorf("Cycle detected in ownership chain")
+		}
+		visited[*key] = true
+		key = owner
+	}
+}
+
+type identityControllerFetcher struct {
+}
+
+func (f *identityControllerFetcher) FindTopLevel(controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	return controller, nil
+}
+
+type constControllerFetcher struct {
+	ControllerKeyWithAPIVersion *ControllerKeyWithAPIVersion
+}
+
+func (f *constControllerFetcher) FindTopLevel(controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	return f.ControllerKeyWithAPIVersion, nil
+}
+
+type mockControllerFetcher struct {
+	expected *ControllerKeyWithAPIVersion
+	result   *ControllerKeyWithAPIVersion
+}
+
+func (f *mockControllerFetcher) FindTopLevel(controller *ControllerKeyWithAPIVersion) (*ControllerKeyWithAPIVersion, error) {
+	if controller == nil && f.expected == nil {
+		return f.result, nil
+	}
+	if controller == nil || *controller != *f.expected {
+		return nil, fmt.Errorf("Unexpected argument: %v", controller)
+	}
+
+	return f.result, nil
+}

--- a/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/controller_fetcher/controller_fetcher_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerfetcher
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+var trueVar = true
+
+func simpleControllerFetcher() *controllerFetcher {
+	f := controllerFetcher{}
+	f.informersMap = make(map[wellKnownController]cache.SharedIndexInformer)
+
+	for _, kind := range wellKnownControllers {
+		f.informersMap[kind] = cache.NewSharedIndexInformer(
+			&cache.ListWatch{},
+			nil,
+			time.Duration(-1),
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	}
+	return &f
+}
+
+func addController(controller *controllerFetcher, obj runtime.Object) {
+	kind := wellKnownController(obj.GetObjectKind().GroupVersionKind().Kind)
+	controller.informersMap[kind].GetStore().Add(obj)
+}
+
+func TestControllerFetcher(t *testing.T) {
+	type testCase struct {
+		apiVersion    string
+		key           *ControllerKeyWithAPIVersion
+		objects       []runtime.Object
+		expectedKey   *ControllerKeyWithAPIVersion
+		expectedError error
+	}
+	for i, tc := range []testCase{
+		{
+			key:           nil,
+			expectedKey:   nil,
+			expectedError: nil,
+		},
+		{
+			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
+			expectedKey:   nil,
+			expectedError: fmt.Errorf("Deployment test-namesapce/test-deployment does not exist"),
+		},
+		{
+			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
+			objects: []runtime.Object{&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namesapce",
+				},
+			}},
+			expectedKey: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}}, // Deployment has no parrent
+			expectedError: nil,
+		},
+		{
+			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-rs", Kind: "ReplicaSet", Namespace: "test-namesapce"}},
+			objects: []runtime.Object{&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namesapce",
+				},
+			}, &appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "ReplicaSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rs",
+					Namespace: "test-namesapce",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Controller: &trueVar,
+							Kind:       "Deployment",
+							Name:       "test-deployment",
+						},
+					},
+				},
+			}},
+			expectedKey: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}}, // Deployment has no parent
+			expectedError: nil,
+		},
+		{
+			key: &ControllerKeyWithAPIVersion{ControllerKey: ControllerKey{
+				Name: "test-deployment", Kind: "Deployment", Namespace: "test-namesapce"}},
+			objects: []runtime.Object{&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "test-namesapce",
+					// Deployment points to itself
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Controller: &trueVar,
+							Kind:       "Deployment",
+							Name:       "test-deployment",
+						},
+					},
+				},
+			}},
+			expectedKey:   nil,
+			expectedError: fmt.Errorf("Cycle detected in ownership chain"),
+		},
+	} {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			f := simpleControllerFetcher()
+			for _, obj := range tc.objects {
+				addController(f, obj)
+			}
+			topLevelController, err := f.FindTopLevel(tc.key)
+			if tc.expectedKey == nil {
+				assert.Nil(t, topLevelController)
+			} else {
+				assert.Equal(t, tc.expectedKey, topLevelController)
+			}
+			if tc.expectedError == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tc.expectedError, err)
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -198,6 +198,13 @@ func TestAggregateContainerStateLoadFromCheckpoint(t *testing.T) {
 func TestAggregateContainerStateIsExpired(t *testing.T) {
 	cs := NewAggregateContainerState()
 	cs.LastSampleStart = testTimestamp
+	cs.TotalSamplesCount = 1
 	assert.False(t, cs.isExpired(testTimestamp.Add(7*24*time.Hour)))
 	assert.True(t, cs.isExpired(testTimestamp.Add(8*24*time.Hour)))
+
+	csEmpty := NewAggregateContainerState()
+	csEmpty.TotalSamplesCount = 0
+	csEmpty.CreationTime = testTimestamp
+	assert.False(t, csEmpty.isExpired(testTimestamp.Add(7*24*time.Hour)))
+	assert.True(t, csEmpty.isExpired(testTimestamp.Add(8*24*time.Hour)))
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -67,6 +67,11 @@ func (conditionsMap *vpaConditionsMap) AsList() []vpa_types.VerticalPodAutoscale
 	return conditions
 }
 
+func (conditionsMap *vpaConditionsMap) ConditionActive(conditionType vpa_types.VerticalPodAutoscalerConditionType) bool {
+	condition, found := (*conditionsMap)[conditionType]
+	return found && condition.Status == apiv1.ConditionTrue
+}
+
 // Vpa (Vertical Pod Autoscaler) object is responsible for vertical scaling of
 // Pods matching a given label selector.
 type Vpa struct {

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -177,9 +177,11 @@ func (vpa *Vpa) matchesAggregation(aggregationKey AggregateStateKey) bool {
 func (vpa *Vpa) UpdateConditions(podsMatched bool) {
 	reason := ""
 	msg := ""
-	if !podsMatched {
+	if podsMatched {
+		delete(vpa.Conditions, vpa_types.NoPodsMatched)
+	} else {
 		reason = "NoPodsMatched"
-		msg = "No live pods match this VPA object"
+		msg = "No pods match this VPA object"
 		vpa.Conditions.Set(vpa_types.NoPodsMatched, true, reason, msg)
 	}
 	if vpa.HasRecommendation() {

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -51,6 +51,7 @@ func TestUpdateConditions(t *testing.T) {
 		podsMatched        bool
 		hasRecommendation  bool
 		expectedConditions []vpa_types.VerticalPodAutoscalerCondition
+		expectedAbsent     []vpa_types.VerticalPodAutoscalerConditionType
 	}{
 		{
 			name:              "Has recommendation",
@@ -64,6 +65,7 @@ func TestUpdateConditions(t *testing.T) {
 					Message: "",
 				},
 			},
+			expectedAbsent: []vpa_types.VerticalPodAutoscalerConditionType{vpa_types.NoPodsMatched},
 		}, {
 			name:              "Has recommendation but no pods matched",
 			podsMatched:       false,
@@ -78,7 +80,7 @@ func TestUpdateConditions(t *testing.T) {
 					Type:    vpa_types.NoPodsMatched,
 					Status:  core.ConditionTrue,
 					Reason:  "NoPodsMatched",
-					Message: "No live pods match this VPA object",
+					Message: "No pods match this VPA object",
 				},
 			},
 		}, {
@@ -93,6 +95,7 @@ func TestUpdateConditions(t *testing.T) {
 					Message: "",
 				},
 			},
+			expectedAbsent: []vpa_types.VerticalPodAutoscalerConditionType{vpa_types.NoPodsMatched},
 		}, {
 			name:              "No recommendation no pods matched",
 			podsMatched:       false,
@@ -102,12 +105,12 @@ func TestUpdateConditions(t *testing.T) {
 					Type:    vpa_types.RecommendationProvided,
 					Status:  core.ConditionFalse,
 					Reason:  "NoPodsMatched",
-					Message: "No live pods match this VPA object",
+					Message: "No pods match this VPA object",
 				}, {
 					Type:    vpa_types.NoPodsMatched,
 					Status:  core.ConditionTrue,
 					Reason:  "NoPodsMatched",
-					Message: "No live pods match this VPA object",
+					Message: "No pods match this VPA object",
 				},
 			},
 		},
@@ -126,6 +129,9 @@ func TestUpdateConditions(t *testing.T) {
 				assert.Equal(t, condition.Status, actualCondition.Status, "Condition: %v", condition.Type)
 				assert.Equal(t, condition.Reason, actualCondition.Reason, "Condition: %v", condition.Type)
 				assert.Equal(t, condition.Message, actualCondition.Message, "Condition: %v", condition.Type)
+			}
+			for _, condition := range tc.expectedAbsent {
+				assert.NotContains(t, vpa.Conditions, condition)
 			}
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -129,9 +129,15 @@ func TestUpdateConditions(t *testing.T) {
 				assert.Equal(t, condition.Status, actualCondition.Status, "Condition: %v", condition.Type)
 				assert.Equal(t, condition.Reason, actualCondition.Reason, "Condition: %v", condition.Type)
 				assert.Equal(t, condition.Message, actualCondition.Message, "Condition: %v", condition.Type)
+				if condition.Status == core.ConditionTrue {
+					assert.True(t, vpa.Conditions.ConditionActive(condition.Type))
+				} else {
+					assert.False(t, vpa.Conditions.ConditionActive(condition.Type))
+				}
 			}
 			for _, condition := range tc.expectedAbsent {
 				assert.NotContains(t, vpa.Conditions, condition)
+				assert.False(t, vpa.Conditions.ConditionActive(condition))
 			}
 		})
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa_test.go
@@ -20,6 +20,11 @@ import (
 	"testing"
 	"time"
 
+	core "k8s.io/api/core/v1"
+	labels "k8s.io/apimachinery/pkg/labels"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,4 +43,90 @@ func TestMergeAggregateContainerState(t *testing.T) {
 	vpa.MergeCheckpointedState(containerNameToAggregateStateMap)
 
 	assert.Contains(t, containerNameToAggregateStateMap, "test")
+}
+
+func TestUpdateConditions(t *testing.T) {
+	cases := []struct {
+		name               string
+		podsMatched        bool
+		hasRecommendation  bool
+		expectedConditions []vpa_types.VerticalPodAutoscalerCondition
+	}{
+		{
+			name:              "Has recommendation",
+			podsMatched:       true,
+			hasRecommendation: true,
+			expectedConditions: []vpa_types.VerticalPodAutoscalerCondition{
+				{
+					Type:    vpa_types.RecommendationProvided,
+					Status:  core.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				},
+			},
+		}, {
+			name:              "Has recommendation but no pods matched",
+			podsMatched:       false,
+			hasRecommendation: true,
+			expectedConditions: []vpa_types.VerticalPodAutoscalerCondition{
+				{
+					Type:    vpa_types.RecommendationProvided,
+					Status:  core.ConditionTrue,
+					Reason:  "",
+					Message: "",
+				}, {
+					Type:    vpa_types.NoPodsMatched,
+					Status:  core.ConditionTrue,
+					Reason:  "NoPodsMatched",
+					Message: "No live pods match this VPA object",
+				},
+			},
+		}, {
+			name:              "No recommendation but pods matched",
+			podsMatched:       true,
+			hasRecommendation: false,
+			expectedConditions: []vpa_types.VerticalPodAutoscalerCondition{
+				{
+					Type:    vpa_types.RecommendationProvided,
+					Status:  core.ConditionFalse,
+					Reason:  "",
+					Message: "",
+				},
+			},
+		}, {
+			name:              "No recommendation no pods matched",
+			podsMatched:       false,
+			hasRecommendation: false,
+			expectedConditions: []vpa_types.VerticalPodAutoscalerCondition{
+				{
+					Type:    vpa_types.RecommendationProvided,
+					Status:  core.ConditionFalse,
+					Reason:  "NoPodsMatched",
+					Message: "No live pods match this VPA object",
+				}, {
+					Type:    vpa_types.NoPodsMatched,
+					Status:  core.ConditionTrue,
+					Reason:  "NoPodsMatched",
+					Message: "No live pods match this VPA object",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			containerName := "container"
+			vpa := NewVpa(VpaID{Namespace: "test-namespace", VpaName: "my-facourite-vpa"}, labels.Nothing(), time.Unix(0, 0))
+			if tc.hasRecommendation {
+				vpa.Recommendation = test.Recommendation().WithContainer(containerName).WithTarget("5", "200").Get()
+			}
+			vpa.UpdateConditions(tc.podsMatched)
+			for _, condition := range tc.expectedConditions {
+				assert.Contains(t, vpa.Conditions, condition.Type)
+				actualCondition := vpa.Conditions[condition.Type]
+				assert.Equal(t, condition.Status, actualCondition.Status, "Condition: %v", condition.Type)
+				assert.Equal(t, condition.Reason, actualCondition.Reason, "Condition: %v", condition.Type)
+				assert.Equal(t, condition.Message, actualCondition.Message, "Condition: %v", condition.Type)
+			}
+		})
+	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go
@@ -108,6 +108,11 @@ func (r *recommender) UpdateVPAs() {
 		} else {
 			vpa.Conditions.Set(vpa_types.RecommendationProvided, false, "", "")
 		}
+		if err := r.clusterState.RecordRecommendation(vpa, time.Now()); err != nil {
+			klog.Warningf("%v", err)
+			klog.V(4).Infof("VPA dump")
+			klog.V(4).Infof("%+v", vpa)
+		}
 		cnt.Add(vpa)
 
 		_, err := vpa_utils.UpdateVpaStatusIfNeeded(

--- a/vertical-pod-autoscaler/pkg/target/fetcher.go
+++ b/vertical-pod-autoscaler/pkg/target/fetcher.go
@@ -18,9 +18,9 @@ package target
 
 import (
 	"fmt"
+	"k8s.io/klog"
 	"time"
 
-	"github.com/golang/glog"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +67,7 @@ const (
 func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Interface, factory informers.SharedInformerFactory) VpaTargetSelectorFetcher {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		glog.Fatalf("Could not create discoveryClient: %v", err)
+		klog.Fatalf("Could not create discoveryClient: %v", err)
 	}
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	restClient := kubeClient.CoreV1().RESTClient()
@@ -91,9 +91,9 @@ func NewVpaTargetSelectorFetcher(config *rest.Config, kubeClient kube_client.Int
 		go informer.Run(stopCh)
 		synced := cache.WaitForCacheSync(stopCh, informer.HasSynced)
 		if !synced {
-			glog.Fatalf("Could not sync cache for %s: %v", kind, err)
+			klog.Fatalf("Could not sync cache for %s: %v", kind, err)
 		} else {
-			glog.Infof("Initial sync of %s completed", kind)
+			klog.Infof("Initial sync of %s completed", kind)
 		}
 	}
 

--- a/vertical-pod-autoscaler/pkg/updater/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/updater/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM k8s.gcr.io/debian-base-amd64:v1.0.0
+FROM k8s.gcr.io/debian-base-amd64:1.0.0
 MAINTAINER Marcin Wielgus "mwielgus@google.com"
 
 ADD updater updater

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -98,11 +98,6 @@ type podReplicaCreator struct {
 
 // CanEvict checks if pod can be safely evicted
 func (e *podsEvictionRestrictionImpl) CanEvict(pod *apiv1.Pod) bool {
-	// check if we hit the rate limit
-	if !e.evictionRateLimiter.Allow() {
-		klog.Warningf("Updater rate limited; Pod can't be evicted.")
-		return false
-	}
 	cr, present := e.podToReplicaCreatorMap[getPodID(pod)]
 	if present {
 		singleGroupStats, present := e.creatorToSingleGroupStatsMap[cr]

--- a/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
+++ b/vertical-pod-autoscaler/pkg/updater/eviction/pods_eviction_restriction.go
@@ -100,6 +100,7 @@ type podReplicaCreator struct {
 func (e *podsEvictionRestrictionImpl) CanEvict(pod *apiv1.Pod) bool {
 	// check if we hit the rate limit
 	if !e.evictionRateLimiter.Allow() {
+		klog.Warningf("Updater rate limited; Pod can't be evicted.")
 		return false
 	}
 	cr, present := e.podToReplicaCreatorMap[getPodID(pod)]

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -164,8 +164,10 @@ func getRateLimiter(evictionRateLimit float64) *rate.Limiter {
 	var evictionRateLimiter *rate.Limiter
 	if evictionRateLimit == -1 || evictionRateLimit == 0 {
 		evictionRateLimiter = rate.NewLimiter(rate.Inf, 0)
+		klog.Info("Rate limit disabled")
 	} else {
 		evictionRateLimiter = rate.NewLimiter(rate.Every(time.Duration(1.0/evictionRateLimit*float64(time.Second))), 0)
+		klog.Infof("Create a rate limit with %f rate equivalent to 1 pod every %+v", evictionRateLimit, time.Duration(1.0/evictionRateLimit*float64(time.Second)))
 	}
 	return evictionRateLimiter
 }

--- a/vertical-pod-autoscaler/pkg/updater/logic/updater.go
+++ b/vertical-pod-autoscaler/pkg/updater/logic/updater.go
@@ -61,7 +61,7 @@ type updater struct {
 }
 
 // NewUpdater creates Updater with given configuration
-func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionRateLimit int, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvictionAdmission, selectorFetcher target.VpaTargetSelectorFetcher) (Updater, error) {
+func NewUpdater(kubeClient kube_client.Interface, vpaClient *vpa_clientset.Clientset, minReplicasForEvicition int, evictionRateLimit float64, evictionToleranceFraction float64, recommendationProcessor vpa_api_util.RecommendationProcessor, evictionAdmission priority.PodEvictionAdmission, selectorFetcher target.VpaTargetSelectorFetcher) (Updater, error) {
 	evictionRateLimiter := getRateLimiter(evictionRateLimit)
 	factory, err := eviction.NewPodsEvictionRestrictionFactory(kubeClient, evictionRateLimiter, minReplicasForEvicition, evictionToleranceFraction)
 	if err != nil {
@@ -160,12 +160,12 @@ func (u *updater) RunOnce() {
 	timer.ObserveTotal()
 }
 
-func getRateLimiter(evictionRateLimit int) *rate.Limiter {
+func getRateLimiter(evictionRateLimit float64) *rate.Limiter {
 	var evictionRateLimiter *rate.Limiter
 	if evictionRateLimit == -1 || evictionRateLimit == 0 {
 		evictionRateLimiter = rate.NewLimiter(rate.Inf, 0)
 	} else {
-		evictionRateLimiter = rate.NewLimiter(rate.Every(time.Duration(1/evictionRateLimit)*time.Second), evictionRateLimit)
+		evictionRateLimiter = rate.NewLimiter(rate.Every(time.Duration(1.0/evictionRateLimit*float64(time.Second))), 0)
 	}
 	return evictionRateLimiter
 }

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -45,6 +45,9 @@ var (
 	evictionToleranceFraction = flag.Float64("eviction-tolerance", 0.5,
 		`Fraction of replica count that can be evicted for update, if more than one pod can be evicted.`)
 
+	evictionRateLimit = flag.Int("eviction-rate-limit", 60, `
+		Number of pods that can be evicted per seconds with a burst of at most the value of the rate.`)
+
 	address = flag.String("address", ":8943", "The address to expose Prometheus metrics.")
 )
 
@@ -72,7 +75,7 @@ func main() {
 		target.NewBeta1TargetSelectorFetcher(config),
 	)
 	// TODO: use SharedInformerFactory in updater
-	updater, err := updater.NewUpdater(kubeClient, vpaClient, *minReplicas, *evictionToleranceFraction, vpa_api_util.NewCappingRecommendationProcessor(), nil, targetSelectorFetcher)
+	updater, err := updater.NewUpdater(kubeClient, vpaClient, *minReplicas, *evictionRateLimit, *evictionToleranceFraction, vpa_api_util.NewCappingRecommendationProcessor(), nil, targetSelectorFetcher)
 	if err != nil {
 		klog.Fatalf("Failed to create updater: %v", err)
 	}

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"time"
 
@@ -81,7 +82,10 @@ func main() {
 	}
 	ticker := time.Tick(*updaterInterval)
 	for range ticker {
-		updater.RunOnce()
+		ctx, cancel := context.WithTimeout(context.Background(), *updaterInterval)
+		updater.RunOnce(ctx)
+		cancel()
 		healthCheck.UpdateLastActivity()
+
 	}
 }

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -45,7 +45,7 @@ var (
 	evictionToleranceFraction = flag.Float64("eviction-tolerance", 0.5,
 		`Fraction of replica count that can be evicted for update, if more than one pod can be evicted.`)
 
-	evictionRateLimit = flag.Int("eviction-rate-limit", -1, `
+	evictionRateLimit = flag.Float64("eviction-rate-limit", -1, `
 		Number of pods that can be evicted per seconds with a burst of at most the value of the rate.`)
 
 	address = flag.String("address", ":8943", "The address to expose Prometheus metrics.")

--- a/vertical-pod-autoscaler/pkg/updater/main.go
+++ b/vertical-pod-autoscaler/pkg/updater/main.go
@@ -45,7 +45,7 @@ var (
 	evictionToleranceFraction = flag.Float64("eviction-tolerance", 0.5,
 		`Fraction of replica count that can be evicted for update, if more than one pod can be evicted.`)
 
-	evictionRateLimit = flag.Int("eviction-rate-limit", 60, `
+	evictionRateLimit = flag.Int("eviction-rate-limit", -1, `
 		Number of pods that can be evicted per seconds with a burst of at most the value of the rate.`)
 
 	address = flag.String("address", ":8943", "The address to expose Prometheus metrics.")

--- a/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
+++ b/vertical-pod-autoscaler/pkg/updater/priority/update_priority_calculator.go
@@ -146,6 +146,7 @@ func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommen
 	for _, podContainer := range pod.Spec.Containers {
 		recommendedRequest := vpa_api_util.GetRecommendationForContainer(podContainer.Name, recommendation)
 		if recommendedRequest == nil {
+			klog.Warningf("Cannot find recommeneded request for container %s", podContainer.Name)
 			continue
 		}
 		for resourceName, recommended := range recommendedRequest.Target {
@@ -177,7 +178,7 @@ func (calc *UpdatePriorityCalculator) getUpdatePriority(pod *apiv1.Pod, recommen
 		resourceDiff += math.Abs(totalRequest-float64(totalRecommended)) / totalRequest
 	}
 	return podPriority{
-		pod:                     pod,
+		pod: pod,
 		outsideRecommendedRange: outsideRecommendedRange,
 		scaleUp:                 scaleUp,
 		resourceDiff:            resourceDiff,


### PR DESCRIPTION
This patch adds a `eviction-rate-limit` flag to the vertical pod
autoscaler component to control the number of evicted pod per seconds.

Fixes #2178