### PR TITLE
Make memory bump following OOM configurable

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/common"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input/history"
-	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
 	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
@@ -51,9 +50,6 @@ var (
 	ctrNamespaceLabel   = flag.String("container-namespace-label", "namespace", `Label name to look for container names`)
 	ctrPodNameLabel     = flag.String("container-pod-name-label", "pod_name", `Label name to look for container names`)
 	ctrNameLabel        = flag.String("container-name-label", "name", `Label name to look for container names`)
-
-	oomBumpUpRatio = flag.Float64("oom-bump-up-ratio", 1.2, `Specifies how much memory will be added after observing OOM`)
-	oomMinBumpUpMb = flag.Float64("oom-min-bump-up",  100, `Specifies minimal increase of memory in MB after observing OOM`)
 )
 
 
@@ -63,9 +59,6 @@ func main() {
 	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender", common.VerticalPodAutoscalerVersion)
 
 	config := createKubeConfig(float32(*kubeApiQps), int(*kubeApiBurst))
-
-	model.OOMBumpUpRatio = *oomBumpUpRatio
-	model.OOMMinBumpUp = *oomMinBumpUpMb * 1024 * 1024 // convert to bytes
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -17,6 +17,7 @@ limitations under the License.
 package model
 
 import (
+	"flag"
 	"fmt"
 	"time"
 
@@ -27,9 +28,12 @@ import (
 
 var (
 	// OOMBumpUpRatio specifies how much memory will be added after observing OOM.
-	OOMBumpUpRatio float64 = 1.2
+	OOMBumpUpRatio = flag.Float64("oom-bump-up-ratio", 1.2, `Specifies how much memory will be added after observing OOM`)
+
 	// OOMMinBumpUp specifies minimal increase of memory after observing OOM.
-	OOMMinBumpUp float64 = 100 * 1024 * 1024 // 100MB
+	OOMMinBumpUpMb = flag.Float64("oom-min-bump-up",  100, `Specifies minimal increase of memory in MB after observing OOM`)
+
+	OOMMinBumpUp float64 = *OOMMinBumpUpMb * 1024 * 1024 // 100MB
 )
 
 // ContainerUsageSample is a measure of resource usage of a container over some
@@ -196,7 +200,7 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	// Omitting oomPeak here to protect against recommendation running too high on subsequent OOMs.
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(OOMMinBumpUp),
-		ScaleResource(memoryUsed, OOMBumpUpRatio))
+		ScaleResource(memoryUsed, *OOMBumpUpRatio))
 
 	klog.Infof("Recording OOM event. Memory used: %v, Memory needed: %v", memoryUsed, memoryNeeded)
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/klog"
 )
 
-const (
+var (
 	// OOMBumpUpRatio specifies how much memory will be added after observing OOM.
 	OOMBumpUpRatio float64 = 1.2
 	// OOMMinBumpUp specifies minimal increase of memory after observing OOM.
@@ -197,6 +197,8 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
 	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(OOMMinBumpUp),
 		ScaleResource(memoryUsed, OOMBumpUpRatio))
+
+	klog.Infof("Recording OOM event. Memory used: %v, Memory needed: %v", memoryUsed, memoryNeeded)
 
 	oomMemorySample := ContainerUsageSample{
 		MeasureStart: timestamp,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -29,7 +29,6 @@ import (
 var (
 	OOMBumpUpRatio = flag.Float64("oom-bump-up-ratio", 1.2, `Specifies how much memory will be added after observing OOM`)
 	OOMMinBumpUpMb = flag.Float64("oom-min-bump-up",  100, `Specifies minimal increase of memory in MB after observing OOM`)
-	OOMMinBumpUp float64 = *OOMMinBumpUpMb * 1024 * 1024
 )
 
 // ContainerUsageSample is a measure of resource usage of a container over some
@@ -195,7 +194,7 @@ func (container *ContainerState) RecordOOM(timestamp time.Time, requestedMemory 
 	// Get max of the request and the recent usage-based memory peak.
 	// Omitting oomPeak here to protect against recommendation running too high on subsequent OOMs.
 	memoryUsed := ResourceAmountMax(requestedMemory, container.memoryPeak)
-	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(OOMMinBumpUp),
+	memoryNeeded := ResourceAmountMax(memoryUsed+MemoryAmountFromBytes(*OOMMinBumpUpMb * 1024 * 1024),
 		ScaleResource(memoryUsed, *OOMBumpUpRatio))
 
 	klog.Infof("Recording OOM event. Memory used: %v, Memory needed: %v", memoryUsed, memoryNeeded)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -27,13 +27,9 @@ import (
 )
 
 var (
-	// OOMBumpUpRatio specifies how much memory will be added after observing OOM.
 	OOMBumpUpRatio = flag.Float64("oom-bump-up-ratio", 1.2, `Specifies how much memory will be added after observing OOM`)
-
-	// OOMMinBumpUp specifies minimal increase of memory after observing OOM.
 	OOMMinBumpUpMb = flag.Float64("oom-min-bump-up",  100, `Specifies minimal increase of memory in MB after observing OOM`)
-
-	OOMMinBumpUp float64 = *OOMMinBumpUpMb * 1024 * 1024 // 100MB
+	OOMMinBumpUp float64 = *OOMMinBumpUpMb * 1024 * 1024
 )
 
 // ContainerUsageSample is a measure of resource usage of a container over some


### PR DESCRIPTION
This allows us to configure the minimum memory bump and scale factor after an OOM has occurred.  